### PR TITLE
Update OnPlatform to return Windows

### DIFF
--- a/Xamarin.Forms.Core/OnPlatform.cs
+++ b/Xamarin.Forms.Core/OnPlatform.cs
@@ -7,6 +7,8 @@ namespace Xamarin.Forms
 		public T iOS { get; set; }
 
 		public T WinPhone { get; set; }
+		
+		public T Windows { get; set; }
 
 		public static implicit operator T(OnPlatform<T> onPlatform)
 		{
@@ -16,9 +18,10 @@ namespace Xamarin.Forms
 					return onPlatform.iOS;
 				case TargetPlatform.Android:
 					return onPlatform.Android;
-				case TargetPlatform.Windows:
 				case TargetPlatform.WinPhone:
 					return onPlatform.WinPhone;
+				case TargetPlatform.Windows:
+					return onPlatform.Windows;
 			}
 
 			return onPlatform.iOS;


### PR DESCRIPTION
Updated OnPlatform to allow the use of Windows as a return type for the XAML extension